### PR TITLE
Add blockchain API endpoints

### DIFF
--- a/main.py
+++ b/main.py
@@ -142,6 +142,66 @@ class Tx(Resource):
         return {"transaction": transaction}, 200
 
 
+class ChainLastBlock(Resource):
+
+    @staticmethod
+    def get():
+        last_block = blockchain.get_chain()[-1]
+        return last_block, 200
+
+
+class ChainValid(Resource):
+
+    @staticmethod
+    def get():
+        return {'is_valid': blockchain.is_chain_valid()}, 200
+
+
+class ChainLastHash(Resource):
+
+    @staticmethod
+    def get():
+        return {'last_hash': blockchain.get_last_block_hash()}, 200
+
+
+class ChainTotalTransactions(Resource):
+
+    @staticmethod
+    def get():
+        total_transactions = sum(len(block['transactions']) for block in blockchain.get_chain())
+        return {'total_transactions': total_transactions}, 200
+
+
+class Mine(Resource):
+    parser = reqparse.RequestParser()
+    parser.add_argument('miner_address', type=str)
+
+    def get(self):
+        args = self.parser.parse_args()
+        miner_address = args.get('miner_address')
+        result = blockchain.mine(miner_address)
+        if result.get('status'):
+            return result, 201
+        return result, 404
+
+
+class BlockHash(Resource):
+
+    @staticmethod
+    def get(block_index):
+        Block.abort_if_block_doesnt_exist(block_index)
+        block = blockchain.get_chain()[block_index]
+        return {'block_hash': blockchain.get_block_hash(block)}, 200
+
+
+class DetermineWinner(Resource):
+
+    @staticmethod
+    def get():
+        winner = blockchain.determine_winner()
+        return {'winner': winner}, 200
+
+
 api.add_resource(Chain, '/chain')
 api.add_resource(ChainTotalTokens, '/chain/total-tokens')
 api.add_resource(ChainTotalBlocks, '/chain/total-blocks')
@@ -152,6 +212,13 @@ api.add_resource(CreateWallet, '/address/create')
 api.add_resource(Tx, '/tx/<string:tx_hash>')
 api.add_resource(TxLargest, '/tx/largest-transaction')
 api.add_resource(TxAverage, '/tx/average-transaction')
+api.add_resource(ChainLastBlock, '/chain/last-block')
+api.add_resource(ChainValid, '/chain/valid')
+api.add_resource(ChainLastHash, '/chain/last-hash')
+api.add_resource(ChainTotalTransactions, '/chain/total-transactions')
+api.add_resource(Mine, '/mine')
+api.add_resource(BlockHash, '/chain/block/<int:block_index>/hash')
+api.add_resource(DetermineWinner, '/determine-winner')
 
 if __name__ == '__main__':
     app.run(debug=True)

--- a/sdk.py
+++ b/sdk.py
@@ -31,3 +31,39 @@ class SDKChain:
                 [i for i in range(25, 36)])))  # create 25 char address
 
             self.post_transaction('the_kings_wallet', random_recipient, random.randint(0, num_transactions))
+
+    def get_last_block(self):
+        url = os.path.join(self.chain_path, 'last-block')
+        resp = requests.get(url)
+        return {'status': resp.status_code, 'data': resp.json()}
+
+    def get_validity(self):
+        url = os.path.join(self.chain_path, 'valid')
+        resp = requests.get(url)
+        return {'status': resp.status_code, 'data': resp.json()}
+
+    def get_last_hash(self):
+        url = os.path.join(self.chain_path, 'last-hash')
+        resp = requests.get(url)
+        return {'status': resp.status_code, 'data': resp.json()}
+
+    def get_total_transactions(self):
+        url = os.path.join(self.chain_path, 'total-transactions')
+        resp = requests.get(url)
+        return {'status': resp.status_code, 'data': resp.json()}
+
+    def mine(self, miner_address=None):
+        url = os.path.join('http://127.0.0.1:5000', 'mine')
+        params = {'miner_address': miner_address} if miner_address else {}
+        resp = requests.get(url, params=params)
+        return {'status': resp.status_code, 'data': resp.json()}
+
+    def get_block_hash(self, block_index):
+        url = os.path.join(self.chain_path, f'block/{block_index}/hash')
+        resp = requests.get(url)
+        return {'status': resp.status_code, 'data': resp.json()}
+
+    def determine_winner(self):
+        url = os.path.join('http://127.0.0.1:5000', 'determine-winner')
+        resp = requests.get(url)
+        return {'status': resp.status_code, 'data': resp.json()}


### PR DESCRIPTION
## Summary
- expose blockchain details with new routes
- include helper methods in SDK for the new endpoints

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68402dfdc41c832cb29696f4fd4addb6