### PR TITLE
Add transaction hashes and pending tx endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ python main.py
 
 The server will listen on `http://127.0.0.1:5000/`.
 
+Each transaction now includes a `transaction_hash` field that uniquely
+identifies it on the chain.
+
 ## Available Endpoints
 
 * `GET /chain` – retrieve the entire blockchain
@@ -36,6 +39,7 @@ The server will listen on `http://127.0.0.1:5000/`.
 * `GET /tx/<hash>` – fetch a transaction by its hash
 * `GET /tx/largest-transaction` – highest value transaction
 * `GET /tx/average-transaction` – average transaction value
+* `GET /pending-transactions` – list unmined transactions
 
 ## SDK Usage
 

--- a/main.py
+++ b/main.py
@@ -172,6 +172,13 @@ class ChainTotalTransactions(Resource):
         return {'total_transactions': total_transactions}, 200
 
 
+class PendingTransactions(Resource):
+
+    @staticmethod
+    def get():
+        return {'pending_transactions': blockchain.get_pending_transactions()}, 200
+
+
 class Mine(Resource):
     parser = reqparse.RequestParser()
     parser.add_argument('miner_address', type=str)
@@ -216,6 +223,7 @@ api.add_resource(ChainLastBlock, '/chain/last-block')
 api.add_resource(ChainValid, '/chain/valid')
 api.add_resource(ChainLastHash, '/chain/last-hash')
 api.add_resource(ChainTotalTransactions, '/chain/total-transactions')
+api.add_resource(PendingTransactions, '/pending-transactions')
 api.add_resource(Mine, '/mine')
 api.add_resource(BlockHash, '/chain/block/<int:block_index>/hash')
 api.add_resource(DetermineWinner, '/determine-winner')

--- a/sdk.py
+++ b/sdk.py
@@ -52,6 +52,11 @@ class SDKChain:
         resp = requests.get(url)
         return {'status': resp.status_code, 'data': resp.json()}
 
+    def get_pending_transactions(self):
+        url = os.path.join('http://127.0.0.1:5000', 'pending-transactions')
+        resp = requests.get(url)
+        return {'status': resp.status_code, 'data': resp.json()}
+
     def mine(self, miner_address=None):
         url = os.path.join('http://127.0.0.1:5000', 'mine')
         params = {'miner_address': miner_address} if miner_address else {}


### PR DESCRIPTION
## Summary
- add unique hashes to every transaction
- expose pending transactions in the API and SDK
- document new endpoint and transaction hash usage

## Testing
- `python -m py_compile discard_token.py main.py sdk.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_68402f7e8ed4832cacad75624011c06b