### PR TITLE
Add unit tests for DiscardToken

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ requests~=2.26.0
 Flask~=2.0.1
 Flask-RESTful~=0.3.9
 Werkzeug<3
+pytest>=7.0

--- a/tests/test_discard_token.py
+++ b/tests/test_discard_token.py
@@ -1,0 +1,57 @@
+import os,sys; sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import pytest
+from discard_token import DiscardToken
+
+def test_genesis_block_exists():
+    chain = DiscardToken()
+    assert len(chain.get_chain()) == 1
+    block = chain.get_chain()[0]
+    assert block['index'] == 0
+    assert block['transactions'][0]['recipient'] == 'the_kings_wallet'
+
+def test_create_transaction_unique_hashes():
+    chain = DiscardToken()
+    tx1 = chain.create_transaction('a','b',1)
+    tx2 = chain.create_transaction('a','b',1)
+    assert tx1['transaction_hash'] != tx2['transaction_hash']
+
+def test_add_transaction_insufficient_balance():
+    chain = DiscardToken()
+    wallet = chain.create_wallet()
+    res = chain.add_transaction(wallet,'b',10)
+    assert res['status'] is False
+    assert 'Insufficient Balance' in res['error']
+
+def test_add_transaction_and_mine():
+    chain = DiscardToken()
+    wallet = chain.create_wallet()
+    res = chain.add_transaction('the_kings_wallet', wallet, 10)
+    assert res['status']
+    tx_hash = res['transaction']['transaction_hash']
+    assert chain.get_pending_transactions()
+    mine_res = chain.mine()
+    assert mine_res['status']
+    assert len(chain.get_chain()) == 2
+    assert not chain.get_pending_transactions()
+    mined_tx = chain.get_tx(tx_hash)
+    assert mined_tx is not None
+
+def test_chain_invalid_after_tamper():
+    chain = DiscardToken()
+    wallet = chain.create_wallet()
+    chain.add_transaction('the_kings_wallet', wallet, 5)
+    chain.mine()
+    chain.chain[1]['transactions'][0]['amount'] = 99
+    assert chain.is_chain_valid() is False
+
+def test_create_wallet_length():
+    wallet = DiscardToken.create_wallet()
+    assert 25 <= len(wallet) <= 35
+
+def test_get_tx_pending_and_mined():
+    chain = DiscardToken()
+    chain.add_transaction('the_kings_wallet','x',3)
+    tx_hash = chain.current_trans[0]['transaction_hash']
+    assert chain.get_tx(tx_hash) is not None
+    chain.mine()
+    assert chain.get_tx(tx_hash) is not None


### PR DESCRIPTION
## Summary
- add pytest to requirements
- create tests for DiscardToken functionality

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68404bdf278c832cbdc8d94ad85cda37