### PR TITLE
Add wallet signatures

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ python main.py
 The server will listen on `http://127.0.0.1:5000/`.
 
 Each transaction now includes a `transaction_hash` field that uniquely
-identifies it on the chain.
+identifies it on the chain. Transactions are signed using the sender's
+private key. Wallet addresses are derived from the SHA256 hash of the
+public key.
 
 ## Available Endpoints
 
@@ -35,7 +37,7 @@ identifies it on the chain.
 * `GET /chain/block/<index>` – fetch a block by index
 * `GET /all-addresses` – list every known wallet address
 * `GET /address/<address>` – view balance details for an address
-* `GET /address/create` – generate a new wallet address
+* `GET /address/create` – generate a new wallet with keys
 * `GET /tx/<hash>` – fetch a transaction by its hash
 * `GET /tx/largest-transaction` – highest value transaction
 * `GET /tx/average-transaction` – average transaction value
@@ -51,6 +53,11 @@ from sdk import SDKChain
 client = SDKChain('chain')
 response = client.get_chain()
 print(response)
+
+# Creating and posting a signed transaction
+wallet = client.create_wallet()  # GET /address/create
+tx = SDKChain.create_transaction(wallet['private_key'], wallet['address'], 'some_recipient', 10)
+client.post_transaction(tx)
 ```
 
 ## License

--- a/main.py
+++ b/main.py
@@ -16,10 +16,6 @@ blockchain = DiscardToken()
 
 
 class Chain(Resource):
-    parser = reqparse.RequestParser()
-    parser.add_argument('sender', type=str)
-    parser.add_argument('recipient', type=str)
-    parser.add_argument('amount', type=int)
 
     # get blockchain
     @staticmethod
@@ -29,17 +25,8 @@ class Chain(Resource):
 
     # add transaction and block to blockchain
     def post(self):
-        # get args
-        args = self.parser.parse_args()
-        sender = args.get('sender')
-        recipient = args.get('recipient')
-        amount = args.get('amount')
-
-        # add transaction to block
-        is_transaction_added = blockchain.add_transaction(
-            sender,
-            recipient,
-            amount)
+        tx_data = request.get_json(force=True)
+        is_transaction_added = blockchain.add_transaction(tx_data)
 
         # add block to chain
         if is_transaction_added.get('status'):
@@ -125,8 +112,8 @@ class CreateWallet(Resource):
 
     @staticmethod
     def get():
-        wallet_address = blockchain.create_wallet()
-        return {"wallet_address": wallet_address}, 200
+        wallet = blockchain.create_wallet()
+        return wallet, 200
 
 
 class Tx(Resource):

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ requests~=2.26.0
 Flask~=2.0.1
 Flask-RESTful~=0.3.9
 Werkzeug<3
+cryptography

--- a/sdk.py
+++ b/sdk.py
@@ -1,8 +1,13 @@
 import os
 import random
 import string
+import json
+import time
+import hashlib
 
 import requests
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
 
 
 class SDKChain:
@@ -18,19 +23,62 @@ class SDKChain:
         data = r_get_chain.json()
         return {'status': status, 'data': data}
 
-    def post_transaction(self, sender, recipient, amount):
-        transaction = {'sender': sender, 'recipient': recipient, 'amount': amount}
-        r_post_transaction = requests.post(self.chain_path, data=transaction)
+    @staticmethod
+    def create_wallet():
+        resp = requests.get('http://127.0.0.1:5000/address/create')
+        return resp.json()
+
+    @staticmethod
+    def create_transaction(private_key_pem, sender, recipient, amount):
+        private_key = serialization.load_pem_private_key(private_key_pem.encode(), password=None)
+        payload = {
+            'sender': sender,
+            'recipient': recipient,
+            'amount': amount,
+            'timestamp': time.time(),
+            'nonce': random.random(),
+        }
+        tx = payload.copy()
+        tx['transaction_hash'] = hashlib.sha256(
+            json.dumps(payload, sort_keys=True).encode()
+        ).hexdigest()
+        signature = private_key.sign(
+            json.dumps(payload, sort_keys=True).encode(),
+            ec.ECDSA(hashes.SHA256()),
+        )
+        tx['signature'] = signature.hex()
+        tx['public_key'] = private_key.public_key().public_bytes(
+            serialization.Encoding.PEM,
+            serialization.PublicFormat.SubjectPublicKeyInfo,
+        ).decode()
+        return tx
+
+    def post_transaction(self, transaction):
+        r_post_transaction = requests.post(self.chain_path, json=transaction)
         status = r_post_transaction.status_code
         data = r_post_transaction.json()
         return {'status': status, 'data': data}
 
     def create_fake_transactions(self, num_transactions):
-        for i in range(num_transactions):
-            random_recipient = ''.join(random.choices(string.ascii_letters + string.digits, k=random.choice(
-                [i for i in range(25, 36)])))  # create 25 char address
-
-            self.post_transaction('the_kings_wallet', random_recipient, random.randint(0, num_transactions))
+        for _ in range(num_transactions):
+            random_recipient = ''.join(
+                random.choices(string.ascii_letters + string.digits, k=32)
+            )
+            tx = {
+                'sender': 'the_kings_wallet',
+                'recipient': random_recipient,
+                'amount': random.randint(0, num_transactions),
+                'timestamp': time.time(),
+                'nonce': random.random(),
+                'transaction_hash': '',
+                'signature': '',
+                'public_key': '',
+            }
+            # Unsigned transactions for fake data
+            tx['transaction_hash'] = hashlib.sha256(
+                json.dumps({k: tx[k] for k in ['sender','recipient','amount','timestamp','nonce']}, sort_keys=True).encode()
+            ).hexdigest()
+            self.post_transaction(tx)
 
     def get_last_block(self):
         url = os.path.join(self.chain_path, 'last-block')

--- a/tests/test_signature.py
+++ b/tests/test_signature.py
@@ -1,0 +1,22 @@
+import unittest
+from discard_token import DiscardToken
+
+class TestSignature(unittest.TestCase):
+    def test_forged_transaction_rejected(self):
+        bc = DiscardToken()
+        sender = bc.create_wallet()
+        recipient = bc.create_wallet()
+        bc.mine(sender['address'])  # reward sender so they have balance
+        tx = bc.create_transaction(sender['address'], recipient['address'], 5, sender['private_key'])
+        res = bc.add_transaction(tx)
+        self.assertTrue(res['status'])
+
+        # Forge tx with wrong key
+        fake_wallet = bc.create_wallet()
+        forged_tx = bc.create_transaction(sender['address'], recipient['address'], 5, fake_wallet['private_key'])
+        forged_tx['sender'] = sender['address']
+        res2 = bc.add_transaction(forged_tx)
+        self.assertFalse(res2['status'])
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add ECDSA wallet generation
- sign and verify transactions
- expose keys from `/address/create`
- post signed transactions via the API and SDK
- test invalid signatures

## Testing
- `python -m unittest tests.test_signature -v`


------
https://chatgpt.com/codex/tasks/task_e_68404c9fe174832c847e606296a31e75