### PR TITLE
Add persistence layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ identifies it on the chain. Transactions are signed using the sender's
 private key. Wallet addresses are derived from the SHA256 hash of the
 public key.
 
+The blockchain state is stored in `chain_data.json` in the project
+directory so that the chain and any pending transactions survive server
+restarts.
+
 ## Available Endpoints
 
 * `GET /chain` – retrieve the entire blockchain


### PR DESCRIPTION
## Summary
- add persistence layer to store blockchain and pending transactions in `chain_data.json`
- update README with info about saved state
- modify tests to work with transaction signatures and persistence setup

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68404fb0a5cc832c8ce90a63544ad09e