### PR TITLE
Implement dynamic difficulty adjustment

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ restarts.
 Balances include pending outgoing transfers so double spends cannot be
 submitted before mining completes.
 
+The mining difficulty automatically adjusts after each block to target
+approximately one second per block. The difficulty will never fall below
+1 or rise above 6.
+
 ## Available Endpoints
 
 * `GET /chain` – retrieve the entire blockchain


### PR DESCRIPTION
## Summary
- implement a simple difficulty retargeting algorithm
- persist difficulty between runs
- document new behaviour in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684052aab2d0832cafa2ac6ac69fcd98