### PR TITLE
Add encrypted wallet storage to SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,11 @@ print(response)
 wallet = client.create_wallet()  # GET /address/create
 tx = SDKChain.create_transaction(wallet['private_key'], wallet['address'], 'some_recipient', 10)
 client.post_transaction(tx)
+
+# Save the wallet encrypted on disk
+SDKChain.save_wallet(wallet, 'wallet.dat', 'my-password')
+# Later we can load it again
+wallet = SDKChain.load_wallet('wallet.dat', 'my-password')
 ```
 
 ## License

--- a/tests/test_wallet_encryption.py
+++ b/tests/test_wallet_encryption.py
@@ -1,0 +1,13 @@
+import os,sys; sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from sdk import SDKChain
+from discard_token import DiscardToken
+
+
+def test_save_and_load_wallet(tmp_path):
+    wallet = DiscardToken.create_wallet()
+    file_path = tmp_path / "wallet.dat"
+    SDKChain.save_wallet(wallet, file_path, "secret")
+    loaded = SDKChain.load_wallet(file_path, "secret")
+    assert wallet == loaded
+


### PR DESCRIPTION
## Summary
- enhance wallet functionality in `sdk.py` with helpers for encrypting wallets using a password
- demonstrate wallet encryption in the README
- test saving and loading encrypted wallets

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684054d31fc8832cb12e4e3e50239903