### PR TITLE
Implement mempool validation and transaction fees

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,17 @@ private key. Wallet addresses are derived from the SHA256 hash of the
 public key.
 
 The blockchain state is stored in `chain_data.json` in the project
-directory so that the chain and any pending transactions survive server
-restarts.
+directory so that the chain and the mempool of pending transactions
+survive server restarts.
 
 Balances include pending outgoing transfers so double spends cannot be
 submitted before mining completes.
+
+Transactions require a small fee (default `1` token) which is paid to the
+miner of the block. The fee amount is recorded in the `fee` field of each
+transaction and is included in the signature payload. Duplicate transactions
+or those with non-positive amounts will be rejected before entering the
+mempool.
 
 The mining difficulty automatically adjusts after each block to target
 approximately one second per block. The difficulty will never fall below

--- a/sdk.py
+++ b/sdk.py
@@ -64,12 +64,13 @@ class SDKChain:
         return json.loads(decrypted.decode())
 
     @staticmethod
-    def create_transaction(private_key_pem, sender, recipient, amount):
+    def create_transaction(private_key_pem, sender, recipient, amount, fee=1):
         private_key = serialization.load_pem_private_key(private_key_pem.encode(), password=None)
         payload = {
             'sender': sender,
             'recipient': recipient,
             'amount': amount,
+            'fee': fee,
             'timestamp': time.time(),
             'nonce': random.random(),
         }


### PR DESCRIPTION
## Summary
- enforce transaction fees and include them in mining rewards
- reject duplicate or invalid transactions before adding to mempool
- persist mempool across restarts and document fees in README
- expose fee field in SDK transaction helper

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68405d70f504832ca551ad8c005aa037