### PR TITLE
Add median transaction feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ on receipt before being added to the chain.
 * `GET /tx/<hash>` – fetch a transaction by its hash
 * `GET /tx/largest-transaction` – highest value transaction
 * `GET /tx/average-transaction` – average transaction value
+* `GET /tx/median-transaction` – median transaction value
 * `GET /pending-transactions` – list unmined transactions
 * `POST /register-peer` – register another node's URL and public key
 * `POST /p2p/transaction` – receive a signed transaction from a peer

--- a/discard_token.py
+++ b/discard_token.py
@@ -3,7 +3,7 @@ import random
 import hashlib
 import json
 import time
-from statistics import mean
+from statistics import mean, median
 import string
 
 from cryptography.hazmat.primitives import hashes, serialization
@@ -253,6 +253,13 @@ class DiscardToken:
     def get_average_transaction_amount(self):
         transaction_amount_lst = self.get_transaction_amount_lst()
         return mean(transaction_amount_lst)
+
+    def get_median_transaction_amount(self):
+        """Return the median value of all transactions on the chain."""
+        amounts = self.get_transaction_amount_lst()
+        if not amounts:
+            return 0
+        return median(amounts)
 
     def get_total_tokens(self):
         # sum all transactions

--- a/main.py
+++ b/main.py
@@ -63,6 +63,14 @@ class TxAverage(Resource):
         return average_transaction, 200
 
 
+class TxMedian(Resource):
+
+    @staticmethod
+    def get():
+        median_transaction = {'median_transaction': blockchain.get_median_transaction_amount()}
+        return median_transaction, 200
+
+
 class ChainTotalTokens(Resource):
 
     @staticmethod
@@ -288,6 +296,7 @@ api.add_resource(CreateWallet, '/address/create')
 api.add_resource(Tx, '/tx/<string:tx_hash>')
 api.add_resource(TxLargest, '/tx/largest-transaction')
 api.add_resource(TxAverage, '/tx/average-transaction')
+api.add_resource(TxMedian, '/tx/median-transaction')
 api.add_resource(ChainLastBlock, '/chain/last-block')
 api.add_resource(ChainValid, '/chain/valid')
 api.add_resource(ChainLastHash, '/chain/last-hash')

--- a/sdk.py
+++ b/sdk.py
@@ -136,6 +136,11 @@ class SDKChain:
         resp = requests.get(url)
         return {'status': resp.status_code, 'data': resp.json()}
 
+    def get_median_transaction(self):
+        url = os.path.join(self.chain_path, 'median-transaction')
+        resp = requests.get(url)
+        return {'status': resp.status_code, 'data': resp.json()}
+
     def get_pending_transactions(self):
         url = os.path.join('http://127.0.0.1:5000', 'pending-transactions')
         resp = requests.get(url)

--- a/tests/test_discard_token.py
+++ b/tests/test_discard_token.py
@@ -86,3 +86,17 @@ def test_pending_outgoing_reduces_available_balance():
     tx2 = chain.create_transaction(wallet['address'], second_recipient['address'], 30, wallet['private_key'])
     res2 = chain.add_transaction(tx2)
     assert res2['status'] is False
+
+
+def test_median_transaction_amount():
+    chain = DiscardToken()
+    wallet = chain.create_wallet()
+    chain.mine(wallet['address'])
+    rec1 = chain.create_wallet()
+    rec2 = chain.create_wallet()
+    tx1 = chain.create_transaction(wallet['address'], rec1['address'], 10, wallet['private_key'])
+    tx2 = chain.create_transaction(wallet['address'], rec2['address'], 20, wallet['private_key'])
+    chain.add_transaction(tx1)
+    chain.add_transaction(tx2)
+    chain.mine()
+    assert chain.get_median_transaction_amount() == 20


### PR DESCRIPTION
## Summary
- support computing and retrieving the median transaction value
- expose `/tx/median-transaction` in Flask API
- document the new endpoint
- extend SDK with `get_median_transaction`
- test median statistic

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843249fc62c832c8f6d8dd3b2d2e8b5